### PR TITLE
feat: running_page：地图缩小时左侧汇总按地级市聚合

### DIFF
--- a/src/components/LocationStat/CitiesStat.tsx
+++ b/src/components/LocationStat/CitiesStat.tsx
@@ -2,20 +2,31 @@ import Stat from '@/components/Stat';
 import useActivities from '@/hooks/useActivities';
 import { DIST_UNIT, M_TO_DIST } from '@/utils/utils';
 
-// only support China for now
-const CitiesStat = ({ onClick }: { onClick: (_city: string) => void }) => {
-  const { cities } = useActivities();
+const PREFECTURE_ZOOM_THRESHOLD = 8;
 
-  const citiesArr = Object.entries(cities);
-  citiesArr.sort((a, b) => b[1] - a[1]);
+// only support China for now
+const CitiesStat = ({
+  onClick,
+  zoom,
+}: {
+  onClick: (_city: string) => void;
+  zoom: number;
+}) => {
+  const { cities, prefectureCities } = useActivities();
+
+  const usePrefecture = zoom <= PREFECTURE_ZOOM_THRESHOLD;
+  const data = usePrefecture ? prefectureCities : cities;
+
+  const citiesArr = Object.entries(data);
+  citiesArr.sort((a, b) => b[1].distance - a[1].distance);
   return (
     <div className="cursor-pointer">
       <section>
-        {citiesArr.map(([city, distance]) => (
+        {citiesArr.map(([city, stats]) => (
           <Stat
             key={city}
             value={city}
-            description={` ${(distance / M_TO_DIST).toFixed(0)} ${DIST_UNIT}`}
+            description={` ${stats.count}次 ${(stats.distance / M_TO_DIST).toFixed(0)} ${DIST_UNIT}`}
             citySize={3}
             onClick={() => onClick(city)}
           />

--- a/src/components/LocationStat/LocationSummary.tsx
+++ b/src/components/LocationStat/LocationSummary.tsx
@@ -3,7 +3,7 @@ import useActivities from '@/hooks/useActivities';
 
 // only support China for now
 const LocationSummary = () => {
-  const { years, countries, provinces, cities } = useActivities();
+  const { years, countries, provinces, prefectureCities } = useActivities();
   return (
     <div className="cursor-pointer">
       <section>
@@ -16,8 +16,8 @@ const LocationSummary = () => {
         {provinces ? (
           <Stat value={provinces.length} description=" 个省份" />
         ) : null}
-        {cities ? (
-          <Stat value={Object.keys(cities).length} description=" 个城市" />
+        {prefectureCities ? (
+          <Stat value={Object.keys(prefectureCities).length} description=" 个城市" />
         ) : null}
       </section>
       <hr />

--- a/src/components/LocationStat/index.tsx
+++ b/src/components/LocationStat/index.tsx
@@ -11,12 +11,14 @@ interface ILocationStatProps {
   changeYear: (_year: string) => void;
   changeCity: (_city: string) => void;
   changeTitle: (_title: string) => void;
+  zoom: number;
 }
 
 const LocationStat = ({
   changeYear,
   changeCity,
   changeTitle,
+  zoom,
 }: ILocationStatProps) => (
   <div className="w-full pb-16 lg:w-full lg:pr-16">
     <section className="pb-0">
@@ -33,7 +35,7 @@ const LocationStat = ({
     </section>
     <hr />
     <LocationSummary />
-    <CitiesStat onClick={changeCity} />
+    <CitiesStat onClick={changeCity} zoom={zoom} />
     <PeriodStat onClick={changeTitle} />
     <YearStat year="Total" onClick={changeYear} />
   </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -397,11 +397,12 @@ const Index = () => {
         <h1 className="my-12 mt-6 text-5xl font-extrabold italic">
           <a href={siteUrl}>{siteTitle}</a>
         </h1>
-        {(viewState.zoom ?? 0) <= 3 && IS_CHINESE ? (
+        {(viewState.zoom ?? 0) <= 12 && IS_CHINESE ? (
           <LocationStat
             changeYear={changeYear}
             changeCity={changeCity}
             changeTitle={changeTitle}
+            zoom={viewState.zoom ?? 0}
           />
         ) : (
           <YearsStat year={year} onClick={changeYear} />


### PR DESCRIPTION
MC 任务 ID: 1ab14ba4-229a-42ff-a299-145e4e6f0d6b

## 变更摘要

当地图缩放级别 zoom <= 8 时，左侧列表按地级市聚合；zoom > 8 时恢复区级展示。

### 修改文件

- **useActivities.ts**: 增加 CityStats 接口（含次数+距离），添加 prefectureCities 聚合逻辑（直辖市统一用市名）
- **CitiesStat.tsx**: 接受 zoom 参数，zoom <= 8 显示地级市，zoom > 8 显示区级
- **LocationStat/index.tsx**: 传递 zoom 参数给 CitiesStat
- **LocationSummary.tsx**: 使用 prefectureCities 计算城市数
- **pages/index.tsx**: 将 LocationStat 显示阈值从 zoom<=3 扩展到 zoom<=12，并传递当前 zoom